### PR TITLE
Test: add normative rule to verify CI workflow

### DIFF
--- a/normative_rule_defs/rv32.yaml
+++ b/normative_rule_defs/rv32.yaml
@@ -24,6 +24,9 @@ normative_rule_definitions:
   - name: x0eq0
     summary: Register x0 always zero
     tags: ["norm:x0eq0"]
+  - name: test_ci_workflow_rule
+    summary: Test rule for CI workflow verification
+    tags: ["norm:test_ci_workflow_rule"]
   - name: taken_cti_misaligned_exc
     summary: CTI misaligned execution
     tags: ["norm:taken_cti_misaligned_exc"]

--- a/src/rv32.adoc
+++ b/src/rv32.adoc
@@ -378,6 +378,7 @@ include::images/wavedrom/int-reg-reg.edn[]
 [#norm:add_op]#ADD performs the addition of _rs1_ and _rs2_.#
 [#norm:sub_op]#SUB performs the subtraction of _rs2_ from _rs1_.#
 [#norm:add_sub_overflow]#Overflows are ignored and the low XLEN bits of results are written to the destination _rd_.#
+[#norm:test_ci_workflow_rule]#This is a test normative rule to verify the CI workflow creates issues for new additions.#
 [#norm:slt_sltu_op]#SLT and SLTU perform signed and unsigned compares respectively, writing 1 to _rd_ if
 _rs1_ < _rs2_, 0 otherwise.#
 Note, SLTU _rd_, _x0_, _rs2_ sets _rd_ to 1 if _rs2_ is not equal to zero,


### PR DESCRIPTION
## Test PR for CI Workflow

This PR adds a test normative rule to verify:
1. PR gets a comment when normative changes are detected
2. Issue with `NormRules` label is created when merged

### Changes
- Added `[#norm:test_ci_workflow_rule]` to `src/rv32.adoc`
- Added corresponding YAML definition in `normative_rule_defs/rv32.yaml`

### Expected Behavior
- [ ] Workflow comments on this PR
- [ ] After merge, an issue is created with `NormRules` label